### PR TITLE
Fix TMA BackButton click handling

### DIFF
--- a/.changeset/curvy-lions-push.md
+++ b/.changeset/curvy-lions-push.md
@@ -1,0 +1,5 @@
+---
+"@tma.js/navigation": patch
+---
+
+Make `HashNavigator.back()` not method but property. This made TMA BackButton click handling work incorrectly.

--- a/packages/navigation/src/hash/HashNavigator.ts
+++ b/packages/navigation/src/hash/HashNavigator.ts
@@ -149,9 +149,7 @@ export class HashNavigator {
    * Goes back in history.
    * @returns Promise which will be resolved when transition was completed.
    */
-  back(): Promise<void> {
-    return this.go(-1);
-  }
+  back = (): Promise<void> => this.go(-1);
 
   /**
    * Detaches current navigator from the browser history.


### PR DESCRIPTION
Make `HashNavigator.back()` not method but property. This made TMA BackButton click handling work incorrectly.