### PR TITLE
Implement navigator integration for solid. Provide some more features

### DIFF
--- a/.changeset/flat-cherries-clean.md
+++ b/.changeset/flat-cherries-clean.md
@@ -1,0 +1,5 @@
+---
+"@tma.js/solid-router-integration": patch
+---
+
+Implement package.

--- a/.changeset/lazy-walls-enjoy.md
+++ b/.changeset/lazy-walls-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@tma.js/event-emitter": minor
+---
+
+Improve `emit` method code. Return remove event listener function from `on` and `once` methods. Do the same with `subscribe` method. `off` and `unsubscribe` methods now remove only 1 listener, not all its instances.

--- a/.changeset/red-ants-admire.md
+++ b/.changeset/red-ants-admire.md
@@ -1,0 +1,5 @@
+---
+"@tma.js/sdk": patch
+---
+
+`BackButton.on` and `MainButton.on` now return function which removes event listener.

--- a/.changeset/unlucky-hounds-laugh.md
+++ b/.changeset/unlucky-hounds-laugh.md
@@ -1,0 +1,5 @@
+---
+"@tma.js/navigation": patch
+---
+
+Implement `getHash` method.

--- a/apps/local-playground/index.ts
+++ b/apps/local-playground/index.ts
@@ -1,8 +1,13 @@
-/*
-* You can import any code from the other folders in mono-repo. For example, you could
-* use this code:
-*
-* import { postEvent } from '../../packages/bridge/src/index.js';
-*
-* And test postEvent function here.
-* */
+/**
+ * You can import any code from other packages here. There are currently 2 shortcuts:
+ *
+ * 1. "@packages/*". Provides access to "packages" directory:
+ * import { postEvent } from '@packages/bridge/src/index.js';
+ *
+ * 2. "@/*". Provides easy access to packages' index files:
+ * import { postEvent } from '@/bridge';
+ */
+
+import { postEvent } from '@/bridge';
+
+postEvent('web_app_expand');

--- a/apps/local-playground/tsconfig.json
+++ b/apps/local-playground/tsconfig.json
@@ -22,7 +22,8 @@
     "strict": true,
     "target": "ESNext",
     "paths": {
-      "@navigation/*": ["../../packages/navigation/src/*"]
+      "@/*": ["../../packages/*/src/index.ts"],
+      "@packages/*": ["../../packages/*"]
     }
   },
   "exclude": ["node_modules"]

--- a/apps/local-playground/vite.config.ts
+++ b/apps/local-playground/vite.config.ts
@@ -1,6 +1,31 @@
-import { defineConfig } from 'vite';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type ServerOptions } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+
+// TODO: Add docs link for getServerOptions.
+
+/**
+ * Returns Vite dev server options.
+ */
+function getServerOptions(): ServerOptions {
+  const dir = dirname(fileURLToPath(import.meta.url));
+
+  return {
+    port: 3000,
+    https: {
+      cert: readFileSync(resolve(dir, ' ../../https-cert.pem')),
+      key: readFileSync(resolve(dir, ' ../../https-key.pem')),
+    },
+    host: 'tma.internal',
+  };
+}
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
+  // Comment this line in case, you would like to run Vite dev server using HTTP. Otherwise,
+  // it would be launched using HTTPS protocol.
+  server: getServerOptions(),
 });
+

--- a/apps/local-playground/vite.config.ts
+++ b/apps/local-playground/vite.config.ts
@@ -13,10 +13,10 @@ function getServerOptions(): ServerOptions {
   const dir = dirname(fileURLToPath(import.meta.url));
 
   return {
-    port: 3000,
+    port: 443,
     https: {
-      cert: readFileSync(resolve(dir, ' ../../https-cert.pem')),
-      key: readFileSync(resolve(dir, ' ../../https-key.pem')),
+      cert: readFileSync(resolve(dir, '../../https-cert.pem')),
+      key: readFileSync(resolve(dir, '../../https-key.pem')),
     },
     host: 'tma.internal',
   };

--- a/apps/solid-sdk-example/package.json
+++ b/apps/solid-sdk-example/package.json
@@ -24,7 +24,13 @@
     "vite-plugin-solid": "^2.7.0"
   },
   "dependencies": {
-    "@tma.js/sdk-solid": "workspace:*",
+    "@solidjs/router": "^0.8.3",
+    "@tma.js/colors": "^0.0.5",
+    "@tma.js/init-data": "^0.2.19",
+    "@tma.js/navigation": "workspace:*",
+    "@tma.js/sdk": "^0.12.6",
+    "@tma.js/sdk-solid": "^0.1.13",
+    "@tma.js/solid-router-integration": "workspace:*",
     "solid-js": "^1.7.6"
   }
 }

--- a/apps/solid-sdk-example/src/App.tsx
+++ b/apps/solid-sdk-example/src/App.tsx
@@ -1,0 +1,38 @@
+import {
+  Routes,
+  Route,
+  Navigate,
+  Router,
+} from '@solidjs/router';
+import { createIntegration } from '@tma.js/solid-router-integration';
+import { fromLocation, fromHistory } from '@tma.js/navigation';
+
+import { InitDataPage } from './pages/InitDataPage';
+import { ThemeParamsPage } from './pages/ThemeParamsPage';
+
+export function App() {
+  // We should create navigator to pass it to integration creation. First of all, we are
+  // trying to recreate from current browser history due to the reason, current page could be
+  // just reloaded. In this case, navigator will restore its latest state.
+  // If restoration was unsuccessful, we are creating navigator from the current browser location.
+  // FIXME: Restoration will not work in Telegram Web as long as web version recreates whole
+  //  iframe breaking browser history. We should restore from the sessionStorage then.
+  //  Issue: https://github.com/Telegram-Mini-Apps/tma.js/issues/150
+  const navigator =
+    fromHistory({ debug: true }) ||
+    fromLocation({ debug: true });
+
+  // Then, to allow this navigator update current browser history, we should attach it. Otherwise,
+  // it will work in memory mode.
+  void navigator.attach();
+
+  return (
+    <Router source={createIntegration(() => navigator)}>
+      <Routes>
+        <Route path={'/init-data'} component={InitDataPage}/>
+        <Route path={'/theme-params'} component={ThemeParamsPage}/>
+        <Route path={'*'} element={<Navigate href={'/init-data'}/>}/>
+      </Routes>
+    </Router>
+  );
+}

--- a/apps/solid-sdk-example/src/Root.tsx
+++ b/apps/solid-sdk-example/src/Root.tsx
@@ -2,85 +2,10 @@ import {
   createMemo,
   Switch,
   Match,
-  ParentProps,
-  createSignal,
-  createEffect,
-  onMount, onCleanup,
+  type ParentProps,
 } from 'solid-js';
-import { SDKProvider, useSDK, useSDKContext } from '@tma.js/sdk-solid';
-
-function MainButtonTest() {
-  const { mainButton, backButton } = useSDK();
-
-  const [count, setCount] = createSignal(0);
-
-  onMount(() => {
-    const bb = backButton();
-    const mb = mainButton();
-
-    const onMainButtonClick = () => setCount((count) => count + 1);
-    const onBackButtonClick = () => setCount((count) => count - 1);
-
-    mb.enable().show().on('click', onMainButtonClick);
-    bb.on('click', onBackButtonClick);
-
-    onCleanup(() => {
-      mb.hide().off('click', onMainButtonClick);
-      bb.off('click', onBackButtonClick);
-    });
-  });
-
-  createEffect(() => {
-    mainButton().setText(`Count is ${count()}`);
-  });
-
-  createEffect(() => {
-    const bb = backButton();
-
-    if (count() === 0) {
-      bb.hide();
-      return;
-    }
-    bb.show();
-  });
-
-  return null;
-}
-
-/**
- * Displays current application init data.
- */
-function InitData() {
-  const { initData } = useSDK();
-
-  const initDataJson = createMemo(() => {
-    const obj = initData();
-
-    if (!obj) {
-      return 'Init data is empty.';
-    }
-    const { authDate, chat, hash, canSendAfter, queryId, receiver, user, startParam } = obj;
-
-    return JSON.stringify({
-      authDate,
-      chat,
-      hash,
-      canSendAfter,
-      queryId,
-      receiver,
-      user,
-      startParam,
-    }, null, ' ');
-  });
-
-  return (
-    <pre>
-      <code>
-        {initDataJson()}
-      </code>
-    </pre>
-  );
-}
+import { SDKProvider, useSDKContext } from '@tma.js/sdk-solid';
+import { App } from './App';
 
 /**
  * Component which is responsible for controlling SDK init process.
@@ -122,8 +47,7 @@ export function Root() {
   return (
     <SDKProvider initOptions={{ debug: true, cssVars: true, timeout: 1000 }}>
       <DisplayGate>
-        <InitData/>
-        <MainButtonTest/>
+        <App/>
       </DisplayGate>
     </SDKProvider>
   );

--- a/apps/solid-sdk-example/src/components/DisplayData/DisplayData.tsx
+++ b/apps/solid-sdk-example/src/components/DisplayData/DisplayData.tsx
@@ -1,0 +1,82 @@
+import { For, Match, Switch } from 'solid-js';
+import { isRGB, type RGB } from '@tma.js/colors';
+
+import styles from './styles.module.css';
+
+type LineValue = string | null | Line[];
+export type Line = [title: string, value: LineValue];
+
+interface DisplayDataProps {
+  title: string;
+  lines: Line[];
+}
+
+interface DataLineProps {
+  title: string;
+  value: LineValue;
+}
+
+interface DisplayRGBProps {
+  color: RGB;
+}
+
+function DisplayRGB(props: DisplayRGBProps) {
+  return (
+    <div class={styles.colorWrapper}>
+      <div
+        class={styles.color}
+        style={{ 'background-color': props.color }}
+      />
+      {props.color}
+    </div>
+  );
+}
+
+function DataLine(props: DataLineProps) {
+  return (
+    <div class={styles.line}>
+      <Switch>
+        <Match when={Array.isArray(props.value) ? props.value : false}>
+          {(lines) => <DisplayData title={props.title} lines={lines()}/>}
+        </Match>
+        <Match when={true}>
+          <div class={styles.lineTitle}>
+            {props.title}
+          </div>
+          <div class={styles.lineValue}>
+            <code>
+              <Switch fallback={<i>No data</i>}>
+                <Match
+                  when={typeof props.value === 'string' && isRGB(props.value) ? props.value : false}
+                >
+                  {(rgb) => <DisplayRGB color={rgb()}/>}
+                </Match>
+                <Match when={typeof props.value === 'string' ? props.value : false}>
+                  {(stringValue) => stringValue()}
+                </Match>
+              </Switch>
+            </code>
+          </div>
+        </Match>
+      </Switch>
+    </div>
+  );
+}
+
+export function DisplayData(props: DisplayDataProps) {
+  return (
+    <div class={styles.root}>
+      <div class={styles.title}>
+        {props.title}
+      </div>
+      <For each={props.lines}>
+        {([title, value]) => (
+          <DataLine
+            title={title}
+            value={value}
+          />
+        )}
+      </For>
+    </div>
+  );
+}

--- a/apps/solid-sdk-example/src/components/DisplayData/index.ts
+++ b/apps/solid-sdk-example/src/components/DisplayData/index.ts
@@ -1,0 +1,1 @@
+export * from './DisplayData';

--- a/apps/solid-sdk-example/src/components/DisplayData/styles.module.css
+++ b/apps/solid-sdk-example/src/components/DisplayData/styles.module.css
@@ -1,0 +1,37 @@
+.root {
+  font-size: 0.95em;
+}
+
+.title {
+  font-weight: bold;
+  font-size: 1.8em;
+  padding-bottom: 10px;
+}
+
+.line {
+  padding-bottom: 15px;
+}
+
+.lineTitle {
+  font-weight: bold;
+  padding-bottom: 5px;
+  font-size: 1.2em;
+}
+
+.lineValue {
+  white-space: normal;
+  word-break: break-word;
+}
+
+.colorWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.color {
+  width: 18px;
+  height: 18px;
+  border: 1px solid #555;
+  border-radius: 50%;
+  margin-right: 5px;
+}

--- a/apps/solid-sdk-example/src/components/Link/Link.tsx
+++ b/apps/solid-sdk-example/src/components/Link/Link.tsx
@@ -1,0 +1,7 @@
+import { Link as RouterLink, LinkProps } from '@solidjs/router';
+
+import styles from './styles.module.css';
+
+export function Link(props: LinkProps) {
+  return <RouterLink {...props} classList={{ [props.class || '']: true, [styles.root]: true }}/>;
+}

--- a/apps/solid-sdk-example/src/components/Link/index.ts
+++ b/apps/solid-sdk-example/src/components/Link/index.ts
@@ -1,0 +1,1 @@
+export * from './Link';

--- a/apps/solid-sdk-example/src/components/Link/styles.module.css
+++ b/apps/solid-sdk-example/src/components/Link/styles.module.css
@@ -1,0 +1,4 @@
+.root {
+  text-decoration: none;
+  color: var(--tg-theme-link-color, red);
+}

--- a/apps/solid-sdk-example/src/pages/InitDataPage/InitDataPage.tsx
+++ b/apps/solid-sdk-example/src/pages/InitDataPage/InitDataPage.tsx
@@ -1,0 +1,100 @@
+import { Match, Switch } from 'solid-js';
+import { useSDK } from '@tma.js/sdk-solid';
+import type { Chat, User } from '@tma.js/init-data';
+
+import { Link } from '../../components/Link';
+import { DisplayData, type Line } from '../../components/DisplayData';
+
+import styles from './styles.module.css';
+
+function getUserLines(user: User): Line[] {
+  const {
+    id,
+    isBot,
+    isPremium,
+    languageCode = null,
+    lastName = null,
+    firstName,
+  } = user;
+
+  return [
+    ['ID', id.toString()],
+    ['Last name', lastName],
+    ['First name', firstName],
+    ['Is bot', isBot ? 'yes' : 'no'],
+    ['Is premium', isPremium ? 'yes' : 'no'],
+    ['Language code', languageCode],
+  ];
+}
+
+function getChatLines(chat: Chat): Line[] {
+  const {
+    id,
+    title,
+    type,
+    username = null,
+    photoUrl = null,
+  } = chat;
+
+  return [
+    ['ID', id.toString()],
+    ['Title', title],
+    ['Type', type],
+    ['Username', username],
+    ['Photo URL', photoUrl],
+  ];
+}
+
+export function InitDataPage() {
+  const { initData, initDataRaw } = useSDK();
+  const whenWithData = () => {
+    const typed = initData();
+    const raw = initDataRaw();
+
+    return typed && raw ? { typed, raw } : false;
+  };
+
+  return (
+    <div class={styles.root}>
+      <Link class={styles.link} href="/theme-params">
+        To theme parameters
+      </Link>
+      <Switch fallback={'Current launch parameters don\'t contain init data information.'}>
+        <Match when={whenWithData()}>
+          {(match) => {
+            const lines = (): Line[] => {
+              const {
+                authDate,
+                chat,
+                hash,
+                canSendAfter,
+                queryId,
+                receiver,
+                user,
+                startParam,
+                chatType,
+                chatInstance,
+              } = match().typed;
+
+              return [
+                ['Raw', match().raw],
+                ['Auth date', authDate.toLocaleString()],
+                ['Hash', hash],
+                ['Can send after', canSendAfter ? canSendAfter.toString() : null],
+                ['Query id', queryId],
+                ['Start param', startParam],
+                ['Chat type', chatType],
+                ['Chat instance', chatInstance],
+                ['Receiver', receiver ? getUserLines(receiver) : null],
+                ['Chat', chat ? getChatLines(chat) : null],
+                ['User', user ? getUserLines(user) : null],
+              ];
+            };
+
+            return <DisplayData title="Init data" lines={lines()}/>;
+          }}
+        </Match>
+      </Switch>
+    </div>
+  );
+}

--- a/apps/solid-sdk-example/src/pages/InitDataPage/index.ts
+++ b/apps/solid-sdk-example/src/pages/InitDataPage/index.ts
@@ -1,0 +1,1 @@
+export * from './InitDataPage';

--- a/apps/solid-sdk-example/src/pages/InitDataPage/styles.module.css
+++ b/apps/solid-sdk-example/src/pages/InitDataPage/styles.module.css
@@ -1,0 +1,8 @@
+.root {
+  padding: 10px;
+}
+
+.link {
+  display: block;
+  padding-bottom: 10px;
+}

--- a/apps/solid-sdk-example/src/pages/ThemeParamsPage/ThemeParamsPage.tsx
+++ b/apps/solid-sdk-example/src/pages/ThemeParamsPage/ThemeParamsPage.tsx
@@ -1,0 +1,49 @@
+import { useSDK } from '@tma.js/sdk-solid';
+import { useNavigate } from '@solidjs/router';
+
+import { Link } from '../../components/Link';
+
+import styles from './styles.module.css';
+import { DisplayData, Line } from '../../components/DisplayData';
+
+export function ThemeParamsPage() {
+  const { themeParams } = useSDK();
+  const navigate = useNavigate();
+  const lines = (): Line[] => {
+    const {
+      backgroundColor,
+      buttonColor,
+      linkColor,
+      secondaryBackgroundColor,
+      textColor,
+      buttonTextColor,
+      hintColor,
+    } = themeParams();
+
+    return [
+      ['Background color', backgroundColor],
+      ['Button background color', buttonColor],
+      ['Button text color', buttonTextColor],
+      ['Link color', linkColor],
+      ['Secondary background color', secondaryBackgroundColor],
+      ['Text color', textColor],
+      ['Hint color', hintColor],
+    ];
+  };
+
+  return (
+    <div class={styles.root}>
+      <Link
+        class={styles.link}
+        href="/init-data"
+        onClick={e => {
+          e.preventDefault();
+          navigate(-1);
+        }}
+      >
+        Go back
+      </Link>
+      <DisplayData title="Theme Params" lines={lines()}/>
+    </div>
+  );
+}

--- a/apps/solid-sdk-example/src/pages/ThemeParamsPage/index.ts
+++ b/apps/solid-sdk-example/src/pages/ThemeParamsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './ThemeParamsPage';

--- a/apps/solid-sdk-example/src/pages/ThemeParamsPage/styles.module.css
+++ b/apps/solid-sdk-example/src/pages/ThemeParamsPage/styles.module.css
@@ -1,0 +1,8 @@
+.root {
+  padding: 10px;
+}
+
+.link {
+  display: block;
+  padding-bottom: 10px;
+}

--- a/apps/solid-sdk-example/vite.config.ts
+++ b/apps/solid-sdk-example/vite.config.ts
@@ -1,6 +1,28 @@
-import { defineConfig } from 'vite';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type ServerOptions } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
+
 // import devtools from 'solid-devtools/vite';
+
+// TODO: Add docs link for getServerOptions.
+
+/**
+ * Returns Vite dev server options.
+ */
+function getServerOptions(): ServerOptions {
+  const dir = dirname(fileURLToPath(import.meta.url));
+
+  return {
+    port: 443,
+    https: {
+      cert: readFileSync(resolve(dir, '../../https-cert.pem')),
+      key: readFileSync(resolve(dir, '../../https-key.pem')),
+    },
+    host: 'tma.internal',
+  };
+}
 
 export default defineConfig({
   plugins: [
@@ -11,9 +33,9 @@ export default defineConfig({
     // devtools(),
     solidPlugin(),
   ],
-  server: {
-    port: 3000,
-  },
+  // Uncomment this line in case, you would like to run Vite dev server using HTTPS and in case,
+  // you have key and certificate.
+  // server: getServerOptions(),
   build: {
     target: 'esnext',
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@changesets/cli": "^2.26.2",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@turbo/gen": "^1.9.7",
-    "@vitest/coverage-istanbul": "^0.34.6",
     "@vitest/coverage-v8": "^0.34.6",
     "@vitest/ui": "^0.34.6",
     "commitizen": "^4.3.0",

--- a/packages/eslint-config-custom/rules.js
+++ b/packages/eslint-config-custom/rules.js
@@ -14,4 +14,6 @@ module.exports = {
   // We select line endings depending on current OS.
   // See: https://stackoverflow.com/q/39114446/2771889
   'linebreak-style': ['error', (process.platform === 'win32' ? 'windows' : 'unix')],
+  // Sometimes we need to write "void promise".
+  'no-void': 0
 };

--- a/packages/event-emitter/src/EventEmitter.ts
+++ b/packages/event-emitter/src/EventEmitter.ts
@@ -2,22 +2,40 @@ import type {
   AnySubscribeListener,
   EmptyEventName,
   EventListener, EventName,
-  EventParams, NonEmptyEventName,
+  EventParams, NonEmptyEventName, RemoveEventListener,
 } from './types.js';
 
-type EmitterEventListener = EventListener<any> | {
-  listener: EventListener<any>;
-  once: true;
-};
+type AddedEventListener = [listener: EventListener<any>, once: boolean];
 
 /**
- * EventEmitter represents classic JavaScript event emitter. It allows usage
- * both known and unknown events.
+ * Opinionated event emitter implementation.
  */
 export class EventEmitter<Schema> {
-  private readonly listeners: Record<string, EmitterEventListener[]> = {};
+  private readonly listeners: Map<string, AddedEventListener[]> = new Map();
 
   private readonly subscribeListeners: AnySubscribeListener<Schema>[] = [];
+
+  /**
+   * Adds specified event listener.
+   * @param event - event name.
+   * @param listener - event listener.
+   * @param once - should listener called only once.
+   */
+  private addListener<E extends EventName<Schema>>(
+    event: E,
+    listener: EventListener<Schema[E]>,
+    once: boolean,
+  ): RemoveEventListener {
+    let listeners = this.listeners.get(event);
+    if (!listeners) {
+      listeners = [];
+      this.listeners.set(event, listeners);
+    }
+
+    listeners.push([listener, once]);
+
+    return () => this.off(event, listener);
+  }
 
   /**
    * Emits known event which has no parameters.
@@ -38,100 +56,91 @@ export class EventEmitter<Schema> {
   emit(event: EventName<Schema>, ...args: any[]): void {
     this.subscribeListeners.forEach((l) => (l as any)(event, ...args));
 
-    const listeners = this.listeners[event];
-    if (listeners === undefined) {
+    const listeners = this.listeners.get(event);
+    if (!listeners) {
       return;
     }
 
-    // In this array we store all event listeners which should be unbound. We don't unbind
-    // listeners right before call because "off" method will remove all listener entries
-    // in listeners array.
-    const toUnbind: EventListener<any>[] = [];
-
-    listeners.forEach((l) => {
-      if (typeof l === 'function') {
-        l(...args);
-        return;
+    listeners.forEach(([listener, once], idx) => {
+      listener(...args);
+      if (once) {
+        listeners.splice(idx, 1);
       }
-
-      if (l.once) {
-        toUnbind.push(l.listener);
-      }
-      l.listener(...args);
     });
-
-    toUnbind.forEach((l) => this.off(event, l));
   }
 
   /**
    * Adds event listener.
    * @param event - event name.
    * @param listener - event listener.
+   * @returns Function to remove event listener.
    */
-  on<E extends EventName<Schema>>(event: E, listener: EventListener<Schema[E]>): void {
-    const listeners = this.listeners[event];
-
-    if (listeners === undefined) {
-      this.listeners[event] = [listener];
-    } else {
-      listeners.push(listener);
-    }
+  on<E extends EventName<Schema>>(
+    event: E,
+    listener: EventListener<Schema[E]>,
+  ): RemoveEventListener {
+    return this.addListener(event, listener, false);
   }
 
   /**
-   * Adds event listener which will be called only once.
+   * Adds event listener following the logic, described in `on` method, but calls specified
+   * listener only once, removing it after.
    * @param event - event name.
    * @param listener - event listener.
+   * @returns Function to remove event listener.
+   * @see on
    */
-  once<E extends EventName<Schema>>(event: E, listener: EventListener<Schema[E]>): void {
-    const listeners = this.listeners[event];
-    const addedListener = { listener, once: true as const };
-
-    if (listeners === undefined) {
-      this.listeners[event] = [addedListener];
-    } else {
-      listeners.push(addedListener);
-    }
+  once<E extends EventName<Schema>>(
+    event: E,
+    listener: EventListener<Schema[E]>,
+  ): RemoveEventListener {
+    return this.addListener(event, listener, true);
   }
 
   /**
-   * Removes event listener.
+   * Removes event listener. In case, specified listener was bound several times, it removes
+   * only a single one.
    * @param event - event name.
    * @param listener - event listener.
    */
   off<E extends EventName<Schema>>(event: E, listener: EventListener<Schema[E]>): void {
-    const listeners = this.listeners[event];
-    if (listeners === undefined) {
+    const listeners = this.listeners.get(event);
+    if (!listeners) {
       return;
     }
 
     for (let i = 0; i < listeners.length; i += 1) {
-      const l = listeners[i];
-      const currentListener = typeof l === 'function' ? l : l.listener;
-
-      if (listener === currentListener) {
+      if (listener === listeners[i][0]) {
         listeners.splice(i, 1);
-        i -= 1;
+        return;
       }
     }
   }
 
   /**
-   * Subscribes to any events appearing.
+   * Adds event listener to all events.
    * @param listener - events listener.
+   * @returns Function to remove event listener.
+   * @see on
+   * @see once
    */
-  subscribe(listener: AnySubscribeListener<Schema>) {
+  subscribe(listener: AnySubscribeListener<Schema>): RemoveEventListener {
     this.subscribeListeners.push(listener);
+    return () => this.unsubscribe(listener);
   }
 
   /**
-   * Removes listener from global listeners.
+   * Removes global event listener. In case, specified listener was bound several times, it removes
+   * only a single one.
    * @param listener - events listener.
+   * @returns Function to remove event listener.
    */
-  unsubscribe(listener: AnySubscribeListener<Schema>) {
-    const idx = this.subscribeListeners.indexOf(listener);
-    if (idx >= 0) {
-      this.subscribeListeners.splice(idx, 1);
+  unsubscribe(listener: AnySubscribeListener<Schema>): void {
+    for (let i = 0; i < this.subscribeListeners.length; i += 1) {
+      if (this.subscribeListeners[i] === listener) {
+        this.subscribeListeners.splice(i, 1);
+        return;
+      }
     }
   }
 }

--- a/packages/event-emitter/src/types.ts
+++ b/packages/event-emitter/src/types.ts
@@ -53,3 +53,8 @@ export type NonEmptyEventName<Schema> =
 export type AnySubscribeListener<Schema> = {
   [E in keyof Schema]: (event: E, ...args: EventParams<Schema[E]>) => void;
 }[keyof Schema];
+
+/**
+ * Function which removes event listener.
+ */
+export type RemoveEventListener = () => void;

--- a/packages/navigation/README.md
+++ b/packages/navigation/README.md
@@ -1,8 +1,8 @@
 # @tma.js/navigation
 
-[code-link]: https://github.com/Telegram-Mini-Apps/tma.js/tree/master/packages/navigation
-
 [code-badge]: https://img.shields.io/badge/source-black?logo=github
+
+[code-link]: https://github.com/Telegram-Mini-Apps/tma.js/tree/master/packages/navigation
 
 [docs-link]: https://docs.telegram-mini-apps.com/docs/libraries/tma-js-navigation
 
@@ -14,19 +14,11 @@
 
 [size-badge]: https://img.shields.io/bundlephobia/minzip/@tma.js/navigation
 
-[![npm-badge]][npm-link]
-![size-badge]
+[![NPM][npm-badge]][npm-link]
+![Size][size-badge]
 [![docs-badge]][docs-link]
 [![code-badge]][code-link]
 
-[//]: # (Package which provides utilities to simplify communication flow between)
+Custom navigation classes and utilities which could be used to control Mini App navigation.
 
-[//]: # (frontend and Telegram native applications. It also solves some across-platform)
-
-[//]: # (data difference problems to protect developers code and save their time.)
-
-[//]: # (This library is a part of TypeScript packages ecosystem around Telegram Web)
-
-[//]: # (Apps. You can learn more about this package in this)
-
-[//]: # ([documentation]&#40;https://docs.telegram-mini-apps.com/docs/libraries/tma-js-navigation&#41;.)
+This library is a part of TypeScript packages ecosystem around Telegram Web Apps. You can learn more about this package in this [documentation](https://docs.telegram-mini-apps.com/docs/libraries/tma-js-navigation).

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tma.js/navigation",
   "version": "0.0.10",
-  "description": "Custom router to be used in Telegram Mini Apps",
+  "description": "Custom navigation classes and utilities which could be used to control Mini App navigation.",
   "author": "Vladislav Kibenko <wolfram.deus@gmail.com>",
   "homepage": "https://github.com/Telegram-Mini-Apps/tma.js#readme",
   "repository": {

--- a/packages/navigation/src/hash/HashNavigator.ts
+++ b/packages/navigation/src/hash/HashNavigator.ts
@@ -133,7 +133,7 @@ export class HashNavigator {
   }
 
   /**
-   * Attaches current navigator to the browser history.
+   * Attaches current navigator to the browser history allowing navigator to manipulate it.
    */
   async attach(): Promise<void> {
     if (this.attached) {

--- a/packages/navigation/src/hash/fromHistory.ts
+++ b/packages/navigation/src/hash/fromHistory.ts
@@ -18,6 +18,9 @@ const parser = json<NavigatorState>({
  * properly work in case, the last time browser history was managed by some other `Navigator`.
  *
  * Method returns null in case, it was unable to create `Navigator`.
+ *
+ * FIXME: This method will not work as expected in Telegram Web. Learn more:
+ *  https://github.com/Telegram-Mini-Apps/tma.js/issues/150
  * @param options - options passed to constructor.
  */
 export function fromHistory(options?: NavigatorOptions): HashNavigator | null {

--- a/packages/navigation/src/hash/getHash.ts
+++ b/packages/navigation/src/hash/getHash.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns string after first met "#" symbol.
+ * @param value - string to take hash part from.
+ *
+ * @example No hash.
+ * getHash('/path'); // null
+ *
+ * @example Has hash.
+ * getHash('/path#abc'); // 'abc'
+ *
+ * @example Has double hash.
+ * getHash('/path#abc#another'); // 'abc#another'
+ */
+export function getHash(value: string): string | null {
+  const match = value.match(/#(.+)/);
+  return match ? match[1] : null;
+}

--- a/packages/navigation/src/hash/index.ts
+++ b/packages/navigation/src/hash/index.ts
@@ -1,3 +1,4 @@
 export * from './fromHistory.js';
 export * from './fromLocation.js';
+export * from './getHash.js';
 export * from './HashNavigator.js';

--- a/packages/navigation/src/types.ts
+++ b/packages/navigation/src/types.ts
@@ -1,3 +1,5 @@
+import type { EventName } from '@tma.js/event-emitter';
+
 export interface NavigationEntry {
   pathname: string;
   search: string;
@@ -26,6 +28,16 @@ export interface NavigatorEventsMap {
    */
   change: (event: NavigationEntry) => void;
 }
+
+/**
+ * Navigator event name.
+ */
+export type NavigatorEventName = EventName<NavigatorEventsMap>;
+
+/**
+ * Navigator event listener.
+ */
+export type NavigatorEventListener<E extends NavigatorEventName> = NavigatorEventsMap[E];
 
 /**
  * Entry information allowed to be used in push and replace Navigator methods.

--- a/packages/sdk/src/components/BackButton/BackButton.ts
+++ b/packages/sdk/src/components/BackButton/BackButton.ts
@@ -55,13 +55,11 @@ export class BackButton {
    * @param event - event name.
    * @param listener - event listener.
    */
-  on: typeof this.ee.on = (event, listener) => {
-    if (event === 'click') {
-      return on('back_button_pressed', listener as BackButtonEventListener<'click'>);
-    }
-
-    this.ee.on(event, listener);
-  };
+  on: typeof this.ee.on = (event, listener) => (
+    event === 'click'
+      ? on('back_button_pressed', listener as BackButtonEventListener<'click'>)
+      : this.ee.on(event, listener)
+  );
 
   /**
    * Removes event listener.

--- a/packages/sdk/src/components/MainButton/MainButton.ts
+++ b/packages/sdk/src/components/MainButton/MainButton.ts
@@ -156,12 +156,11 @@ export class MainButton {
    * @param event - event name.
    * @param listener - event listener.
    */
-  on: typeof this.ee.on = (event, listener) => {
-    if (event === 'click') {
-      return on('main_button_pressed', listener as MainButtonEventListener<'click'>);
-    }
-    this.ee.on(event, listener);
-  };
+  on: typeof this.ee.on = (event, listener) => (
+    event === 'click'
+      ? on('main_button_pressed', listener as MainButtonEventListener<'click'>)
+      : this.ee.on(event, listener)
+  );
 
   /**
    * Removes event listener.

--- a/packages/solid-router-integration/.eslintrc.cjs
+++ b/packages/solid-router-integration/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['custom/base'],
+};

--- a/packages/solid-router-integration/LICENSE
+++ b/packages/solid-router-integration/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Telegram Web Apps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/solid-router-integration/README.md
+++ b/packages/solid-router-integration/README.md
@@ -1,0 +1,24 @@
+# @tma.js/solid-router-integration
+
+[code-badge]: https://img.shields.io/badge/source-black?logo=github
+
+[code-link]: https://github.com/Telegram-Mini-Apps/tma.js/tree/master/packages/solid-router-integration
+
+[docs-link]: https://docs.telegram-mini-apps.com/docs/libraries/tma-js-solid-router-integration
+
+[docs-badge]: https://img.shields.io/badge/documentation-blue?logo=gitbook&logoColor=white
+
+[npm-link]: https://npmjs.com/package/@tma.js/solid-router-integration
+
+[npm-badge]: https://img.shields.io/npm/v/@tma.js/solid-router-integration?logo=npm
+
+[size-badge]: https://img.shields.io/bundlephobia/minzip/@tma.js/solid-router-integration
+
+[![NPM][npm-badge]][npm-link]
+![Size][size-badge]
+[![docs-badge]][docs-link]
+[![code-badge]][code-link]
+
+[@solidjs/router](https://www.npmjs.com/package/@solidjs/router) integration for navigation.
+
+This library is a part of TypeScript packages ecosystem around Telegram Web Apps. You can learn more about this package in this [documentation](https://docs.telegram-mini-apps.com/docs/libraries/tma-js-solid-router-integration).

--- a/packages/solid-router-integration/package.json
+++ b/packages/solid-router-integration/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@tma.js/solid-router-integration",
+  "version": "0.0.0",
+  "description": "@solidjs/router integration for navigation.",
+  "author": "Vladislav Kibenko <wolfram.deus@gmail.com>",
+  "homepage": "https://github.com/Telegram-Mini-Apps/tma.js#readme",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Telegram-Mini-Apps/tma.js.git",
+    "directory": "packages/solid-router-integration"
+  },
+  "bugs": {
+    "url": "https://github.com/Telegram-Mini-Apps/tma.js/issues"
+  },
+  "keywords": [
+    "telegram-mini-apps",
+    "typescript",
+    "navigation",
+    "solidjs"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/dts/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/dts/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "lint": "eslint -c .eslintrc.cjs src/**/*",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "build": "vite build",
+    "rollup": "pnpm run typecheck && pnpm run build"
+  },
+  "dependencies": {
+    "@tma.js/navigation": "workspace:*"
+  },
+  "peerDependencies": {
+    "@solidjs/router": "^0.x"
+  },
+  "devDependencies": {
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
+    "build-utils": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/solid-router-integration/src/createIntegration.ts
+++ b/packages/solid-router-integration/src/createIntegration.ts
@@ -1,0 +1,106 @@
+import {
+  // @ts-ignore
+  // FIXME: For some reason TypeScript cannot find '@solidjs/router' dependency
+  //  so we have to ignore TS here :(
+  createIntegration as createRouterIntegration,
+  type RouterIntegration,
+} from '@solidjs/router';
+import {
+  getHash,
+  type HashNavigator,
+  type NavigatorEventListener,
+} from '@tma.js/navigation';
+
+type Accessor<T> = () => T;
+
+/**
+ * Guard against selector being an invalid CSS selector.
+ * @param selector - CSS selector.
+ */
+function querySelector<T extends Element>(selector: string) {
+  try {
+    return document.querySelector<T>(selector);
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Scrolls to specified hash.
+ * @param hash - hash to scroll to.
+ * @param fallbackTop - should scroll be performed to the beginning of the page in case
+ * hash was not found on the page.
+ */
+function scrollToHash(hash: string, fallbackTop: boolean) {
+  const el = querySelector(`#${hash}`);
+  if (el) {
+    el.scrollIntoView();
+    return;
+  }
+
+  if (fallbackTop) {
+    window.scrollTo(0, 0);
+  }
+}
+
+/**
+ * Creates integration for `@solidjs/router` package.
+ * @param getNavigator - HashNavigator accessor.
+ */
+export function createIntegration(getNavigator: Accessor<HashNavigator>): RouterIntegration {
+  return createRouterIntegration(
+    // Router calls this getter whenever it wants to get actual navigation state.
+    () => getNavigator().path,
+
+    // Setter is called when some of the router functionality was used. For example, <Navigate/>.
+    ({ scroll = false, value = '', replace = false }) => {
+      if (replace) {
+        getNavigator().replace(value);
+      } else {
+        void getNavigator().push(value);
+      }
+      const hash = getHash(value);
+      if (!hash) {
+        return;
+      }
+
+      const scrollTo = getHash(hash);
+      if (!scrollTo) {
+        return;
+      }
+      scrollToHash(scrollTo, scroll);
+    },
+
+    // This function is called when Router context is initialized. It is the best place to
+    // bind to navigator state changes, which could occur outside.
+    (notify: (value: string) => void) => {
+      const onChange: NavigatorEventListener<'change'> = ({ search, pathname }) => {
+        notify(`${pathname}${search}`);
+      };
+      const navigator = getNavigator();
+      navigator.on('change', onChange);
+
+      return () => {
+        navigator.off('change', onChange);
+      };
+    },
+    {
+      go(delta: number) {
+        getNavigator().go(delta);
+      },
+      renderPath: (path: string) => `#${path}`,
+      parsePath: (str: string) => {
+        const to = str.replace(/^.*?#/, '');
+        if (to.startsWith('/')) {
+          return to;
+        }
+
+        // Hash-only hrefs like `#foo` from plain anchors will come in as `/#foo` whereas a link to
+        // `/foo` will be `/#/foo`. Check if the to starts with a `/` and if not append it as a hash
+        // to the current path so we can handle these in-page anchors correctly.
+        const [, path = '/'] = window.location.hash.split('#', 2);
+        return `${path}#${to}`;
+      },
+    },
+  );
+}

--- a/packages/solid-router-integration/src/index.ts
+++ b/packages/solid-router-integration/src/index.ts
@@ -1,0 +1,1 @@
+export * from './createIntegration.js';

--- a/packages/solid-router-integration/tsconfig.build.json
+++ b/packages/solid-router-integration/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "tsconfig/esnext-dom.json",
+  "include": [
+    "src"
+  ]
+}

--- a/packages/solid-router-integration/tsconfig.eslint.json
+++ b/packages/solid-router-integration/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.build.json",
+  "include": [
+    "src",
+    "tests",
+    "*.ts",
+    "*.js"
+  ]
+}

--- a/packages/solid-router-integration/tsconfig.json
+++ b/packages/solid-router-integration/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "include": [
+    "src",
+    "tests",
+    "*.ts"
+  ]
+}

--- a/packages/solid-router-integration/vite.config.ts
+++ b/packages/solid-router-integration/vite.config.ts
@@ -1,0 +1,9 @@
+import { createViteConfig } from 'build-utils';
+
+import packageJson from './package.json';
+
+export default createViteConfig({
+  packageName: packageJson.name,
+  formats: ['es', 'cjs'],
+  external: ['@tma.js/navigation', '@solidjs/router'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,18 @@ importers:
       '@solidjs/router':
         specifier: ^0.8.3
         version: 0.8.3(solid-js@1.7.6)
+      '@tma.js/colors':
+        specifier: ^0.0.5
+        version: link:../../packages/colors
+      '@tma.js/init-data':
+        specifier: ^0.2.19
+        version: link:../../packages/init-data
       '@tma.js/navigation':
         specifier: workspace:*
         version: link:../../packages/navigation
+      '@tma.js/sdk':
+        specifier: ^0.12.6
+        version: link:../../packages/sdk
       '@tma.js/sdk-solid':
         specifier: ^0.1.13
         version: link:../../packages/sdk-solid

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@turbo/gen':
         specifier: ^1.9.7
         version: 1.9.7(@types/node@20.4.7)(typescript@5.1.6)
-      '@vitest/coverage-istanbul':
-        specifier: ^0.34.6
-        version: 0.34.6(vitest@0.34.6)
       '@vitest/coverage-v8':
         specifier: ^0.34.6
         version: 0.34.6(vitest@0.34.6)
@@ -178,9 +175,18 @@ importers:
 
   apps/solid-sdk-example:
     dependencies:
-      '@tma.js/sdk-solid':
+      '@solidjs/router':
+        specifier: ^0.8.3
+        version: 0.8.3(solid-js@1.7.6)
+      '@tma.js/navigation':
         specifier: workspace:*
+        version: link:../../packages/navigation
+      '@tma.js/sdk-solid':
+        specifier: ^0.1.13
         version: link:../../packages/sdk-solid
+      '@tma.js/solid-router-integration':
+        specifier: workspace:*
+        version: link:../../packages/solid-router-integration
       solid-js:
         specifier: ^1.7.6
         version: 1.7.6
@@ -504,6 +510,25 @@ importers:
       solid-js:
         specifier: ^1.0.0
         version: 1.7.6
+    devDependencies:
+      build-utils:
+        specifier: workspace:*
+        version: link:../build-utils
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:../eslint-config-custom
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+
+  packages/solid-router-integration:
+    dependencies:
+      '@solidjs/router':
+        specifier: ^0.x
+        version: 0.8.3(solid-js@1.7.6)
+      '@tma.js/navigation':
+        specifier: workspace:*
+        version: link:../navigation
     devDependencies:
       build-utils:
         specifier: workspace:*
@@ -4188,6 +4213,14 @@ packages:
       solid-js: 1.7.6
     dev: true
 
+  /@solidjs/router@0.8.3(solid-js@1.7.6):
+    resolution: {integrity: sha512-oJuqQo10rVTiQYhe1qXIG1NyZIZ2YOwHnlLc8Xx+g/iJhFCJo1saLOIrD/Dkh2fpIaIny5ZMkz1cYYqoTYGJbg==}
+    peerDependencies:
+      solid-js: ^1.5.3
+    dependencies:
+      solid-js: 1.7.6
+    dev: false
+
   /@svgr/babel-plugin-add-jsx-attribute@6.5.1(@babel/core@7.22.20):
     resolution: {integrity: sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==}
     engines: {node: '>=10'}
@@ -5160,23 +5193,6 @@ packages:
       vite: 4.4.5(@types/node@20.4.7)
     transitivePeerDependencies:
       - '@swc/helpers'
-    dev: true
-
-  /@vitest/coverage-istanbul@0.34.6(vitest@0.34.6):
-    resolution: {integrity: sha512-5KaBNZPDSk2ybavC3rZ1pWGniw7sJ5usuwVGRUYzJwiBfWvnLpuUer7bjw7qUCRGdKJXrBgb/Dsgif9rkwMX/A==}
-    peerDependencies:
-      vitest: '>=0.32.0 <1'
-    dependencies:
-      istanbul-lib-coverage: 3.2.0
-      istanbul-lib-instrument: 6.0.0
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.1.6
-      picocolors: 1.0.0
-      test-exclude: 6.0.0
-      vitest: 0.34.6(@vitest/ui@0.34.6)(happy-dom@12.5.0)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@vitest/coverage-v8@0.34.6(vitest@0.34.6):
@@ -9903,19 +9919,6 @@ packages:
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /istanbul-lib-instrument@6.0.0:
-    resolution: {integrity: sha512-x58orMzEVfzPUKqlbLd1hXCnySCxKdDKa6Rjg97CwuLLRI4g3FHTdnExu1OqffVFay6zeMW+T6/DowFLndWnIw==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@babel/core': 7.22.20
-      '@babel/parser': 7.22.16
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.0
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /istanbul-lib-report@3.0.1:


### PR DESCRIPTION
Core changes of this pull request bring us Navigator integration for Solid. It is no allowed to use `@tma.js/navigation` along with `@solidjs/router`.

Nevertheless, this feature is not the only one to be brought:
- Improved `local-playrgound` tsconfig by adding `paths` directive, Vite config by allowing to use HTTPS protocol
- Improved `solid-sdk-example` by using new integration there. Added more `@tma.js` dependencies
- Removed some unused workspace deps
- Refactored `@tma.js/event-emitter` and implemented some new features
- Fixed navigation package readme