### PR TITLE
157 add missing init data parameters

### DIFF
--- a/.changeset/breezy-jokes-collect.md
+++ b/.changeset/breezy-jokes-collect.md
@@ -1,0 +1,5 @@
+---
+"@tma.js/sdk": patch
+---
+
+Fix the type of InitData.chatInstance property

--- a/packages/init-data/tests/chat.ts
+++ b/packages/init-data/tests/chat.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { chat } from '../src/index.js';
+
+describe('chat.ts', () => {
+  describe('chat', () => {
+    describe('id', () => {
+      it('should throw an error in case, this property is missing', () => {
+        expect(
+          () => chat().parse({
+            type: 'group chat',
+            title: 'My chat',
+          }),
+        ).toThrow();
+      });
+
+      it('should parse source property as number and pass it to the "id" property', () => {
+        expect(
+          chat().parse({
+            id: 882,
+            type: 'group chat',
+            title: 'My chat',
+          }),
+        ).toMatchObject({
+          id: 882,
+        });
+      });
+    });
+
+    describe('type', () => {
+      it('should throw an error in case, this property is missing', () => {
+        expect(
+          () => chat().parse({
+            id: 223,
+            title: 'My chat',
+          }),
+        ).toThrow();
+      });
+
+      it('should parse source property as number and pass it to the "type" property', () => {
+        expect(
+          chat().parse({
+            id: 882,
+            type: 'group chat',
+            title: 'My chat',
+          }),
+        ).toMatchObject({
+          type: 'group chat',
+        });
+      });
+    });
+
+    describe('title', () => {
+      it('should throw an error in case, this property is missing', () => {
+        expect(
+          () => chat().parse({
+            id: 223,
+            type: 'group chat',
+          }),
+        ).toThrow();
+      });
+
+      it('should parse source property as number and pass it to the "title" property', () => {
+        expect(
+          chat().parse({
+            id: 882,
+            type: 'group chat',
+            title: 'My chat',
+          }),
+        ).toMatchObject({
+          title: 'My chat',
+        });
+      });
+    });
+
+    describe('photo_url', () => {
+      it('should parse source property as number and pass it to the "photoUrl" property', () => {
+        expect(
+          chat().parse({
+            id: 882,
+            type: 'group chat',
+            title: 'My chat',
+            photo_url: 'https://image.com',
+          }),
+        ).toMatchObject({
+          photoUrl: 'https://image.com',
+        });
+      });
+    });
+
+    describe('username', () => {
+      it('should parse source property as number and pass it to the "username" property', () => {
+        expect(
+          chat().parse({
+            id: 882,
+            type: 'group chat',
+            title: 'My chat',
+            username: 'Johny Bravo',
+          }),
+        ).toMatchObject({
+          username: 'Johny Bravo',
+        });
+      });
+    });
+  });
+});

--- a/packages/init-data/tests/initData.ts
+++ b/packages/init-data/tests/initData.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parse } from '../src/index.js';
+import { initData } from '../src/index.js';
 
 function createSearchParams(json: Record<string, unknown>): string {
   const params = new URLSearchParams();
@@ -15,15 +15,15 @@ function createSearchParams(json: Record<string, unknown>): string {
   return params.toString();
 }
 
-describe('parse.ts', () => {
-  describe('parse', () => {
+describe('initData.ts', () => {
+  describe('initData', () => {
     describe('auth_date', () => {
       it('should throw an error in case, this property is missing', () => {
-        expect(() => parse(createSearchParams({ hash: 'abcd' }))).toThrow();
+        expect(() => initData().parse(createSearchParams({ hash: 'abcd' }))).toThrow();
       });
 
       it('should parse source property as Date and pass it to the "authDate" property', () => {
-        expect(parse(createSearchParams({ auth_date: 1, hash: 'abcd' }))).toMatchObject({
+        expect(initData().parse(createSearchParams({ auth_date: 1, hash: 'abcd' }))).toMatchObject({
           authDate: new Date(1000),
         });
       });
@@ -32,7 +32,7 @@ describe('parse.ts', () => {
     describe('can_send_after', () => {
       it('should parse source property as Date and pass it to the "canSendAfter" property', () => {
         expect(
-          parse(createSearchParams({
+          initData().parse(createSearchParams({
             auth_date: 1,
             hash: 'abcd',
             can_send_after: 8882,
@@ -46,7 +46,7 @@ describe('parse.ts', () => {
     describe('chat', () => {
       it('should parse source property as Chat and pass it to the "chat" property', () => {
         expect(
-          parse(createSearchParams({
+          initData().parse(createSearchParams({
             auth_date: 1,
             hash: 'abcd',
             chat: {
@@ -72,7 +72,7 @@ describe('parse.ts', () => {
     describe('hash', () => {
       it('should throw an error in case, this property is missing', () => {
         expect(
-          () => parse(createSearchParams({
+          () => initData().parse(createSearchParams({
             auth_date: 1,
           })),
         ).toThrow();
@@ -80,7 +80,7 @@ describe('parse.ts', () => {
 
       it('should parse source property as string and pass it to the "hash" property', () => {
         expect(
-          parse(createSearchParams({
+          initData().parse(createSearchParams({
             auth_date: 1,
             hash: 'abcd',
           })),
@@ -99,7 +99,7 @@ describe('parse.ts', () => {
       describe(from, () => {
         it(`should parse source property as string and pass it to the "${to}" property`, () => {
           expect(
-            parse(createSearchParams({
+            initData().parse(createSearchParams({
               auth_date: 1,
               hash: 'abcd',
               [from]: 'my custom property',
@@ -115,7 +115,7 @@ describe('parse.ts', () => {
       describe(property, () => {
         it('should parse source property as User and pass it to the property with the same name', () => {
           expect(
-            parse(createSearchParams({
+            initData().parse(createSearchParams({
               auth_date: 1,
               hash: 'abcd',
               [property]: {

--- a/packages/init-data/tests/user.ts
+++ b/packages/init-data/tests/user.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { user } from '../src/index.js';
+
+describe('user.ts', () => {
+  describe('user', () => {
+    describe('first_name', () => {
+      it('should throw an error in case, this property is missing', () => {
+        expect(() => user().parse({ id: 123 })).toThrow();
+      });
+
+      it('should parse source property as string and pass it to the "firstName" property', () => {
+        expect(
+          user().parse({ id: 123, first_name: 'Pavel' }),
+        ).toMatchObject({
+          firstName: 'Pavel',
+        });
+      });
+    });
+
+    describe('id', () => {
+      it('should throw an error in case, this property is missing', () => {
+        expect(() => user().parse({ first_name: 'Pavel' })).toThrow();
+      });
+
+      it('should parse source property as number and pass it to the "id" property', () => {
+        expect(
+          user().parse({
+            id: 123,
+            first_name: 'Pavel',
+          }),
+        ).toMatchObject({
+          id: 123,
+        });
+      });
+    });
+
+    // Check optional booleans.
+    [
+      ['added_to_attachment_menu', 'addedToAttachmentMenu'],
+      ['allows_write_to_pm', 'allowsWriteToPm'],
+      ['is_bot', 'isBot'],
+      ['is_premium', 'isPremium'],
+    ].forEach(([from, to]) => {
+      describe(from, () => {
+        it(`should parse source property as boolean and pass it to the "${to}" property`, () => {
+          expect(
+            user().parse({
+              id: 123,
+              first_name: 'Pavel',
+              [from]: false,
+            }),
+          ).toMatchObject({
+            [to]: false,
+          });
+
+          expect(
+            () => user().parse({
+              id: 123,
+              first_name: 'Pavel',
+              [from]: 'non-boolean',
+            }),
+          ).toThrow();
+        });
+      });
+    });
+
+    // Check optional strings.
+    [
+      ['language_code', 'languageCode'],
+      ['last_name', 'lastName'],
+      ['photo_url', 'photoUrl'],
+      ['username', 'username'],
+    ].forEach(([from, to]) => {
+      describe(from, () => {
+        it(`should parse source property as string and pass it to the "${to}" property`, () => {
+          expect(
+            user().parse({
+              id: 123,
+              first_name: 'Pavel',
+              [from]: 'my custom property',
+            }),
+          ).toMatchObject({
+            [to]: 'my custom property',
+          });
+
+          expect(
+            () => user().parse({
+              id: 123,
+              first_name: 'Pavel',
+              [from]: {
+                key: 'cant parse it',
+              },
+            }),
+          ).toThrow();
+        });
+      });
+    });
+  });
+});

--- a/packages/sdk/src/components/InitData/InitData.ts
+++ b/packages/sdk/src/components/InitData/InitData.ts
@@ -90,7 +90,7 @@ export class InitData {
    * A global identifier indicating the chat from which Mini App was opened. Returned only for
    * applications opened by direct link.
    */
-  get chatInstance(): ChatType | null {
+  get chatInstance(): string | null {
     return this.state.get('chatInstance');
   }
 


### PR DESCRIPTION
I have found out, that missing properties are already added and accessible via `initData.user.allowsWriteToPm`, for example. But in this PR I've added a bunch of tests and fixed the type of `initData.chatInstance`