### PR TITLE
docs(utils): correct initUtils return

### DIFF
--- a/apps/docs/packages/tma-js-sdk/components/utils.md
+++ b/apps/docs/packages/tma-js-sdk/components/utils.md
@@ -9,7 +9,7 @@ To initialize the component, use the `initUtils` function:
 ```typescript
 import { initUtils } from '@tma.js/sdk';
 
-const [utils] = initUtils();  
+const utils = initUtils();  
 ```
 
 ## Links


### PR DESCRIPTION
`initUtils` It is not a hook
<img width="548" alt="image" src="https://github.com/Telegram-Mini-Apps/tma.js/assets/6067222/51ced7dc-a391-483b-ad21-5d4cfc65dc1d">
