### PR TITLE
Fix new npm package name typo

### DIFF
--- a/apps/docs/packages/tma-js-init-data-node.md
+++ b/apps/docs/packages/tma-js-init-data-node.md
@@ -41,7 +41,7 @@ yarn add @tma.js/init-data-node
 Here is the example of how the library can be used:
 
 ```typescript
-import { validate, parse, type InitData } from '@telegram-apps/init-data-node';
+import { validate, parse, type InitData } from '@tma.js/init-data-node';
 import express, {
   type ErrorRequestHandler,
   type RequestHandler,


### PR DESCRIPTION
The example is about @tma.js/init-data-node, not previous package