### PR TITLE
fix: default tgWebAppThemeParams to empty object when missing from launch params

### DIFF
--- a/.changeset/sour-moose-pull.md
+++ b/.changeset/sour-moose-pull.md
@@ -1,0 +1,5 @@
+---
+"@tma.js/transformers": minor
+---
+
+fix: default tgWebAppThemeParams to empty object when missing from launch params

--- a/packages/transformers/src/structures.ts
+++ b/packages/transformers/src/structures.ts
@@ -130,7 +130,7 @@ export function launchParams() {
     tgWebAppPlatform: string(),
     tgWebAppShowSettings: optBool,
     tgWebAppStartParam: optional(string()),
-    tgWebAppThemeParams: pipeJsonToSchema(themeParams()),
+    tgWebAppThemeParams: optional(pipeJsonToSchema(themeParams()), {}),
     tgWebAppVersion: string(),
   } satisfies { [K in keyof LaunchParams]-?: BaseSchema<any, LaunchParams[K], any> });
 }


### PR DESCRIPTION
Mini Apps launched in Guard Mode via sendChatJoinRequestWebApp omit tgWebAppThemeParams, causing schema validation to fail.